### PR TITLE
feat: Add Hedgedoc service to docker-compose

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -80,3 +80,6 @@ include:
   - path: ./gitea/docker-compose.yaml
     project_directory: ..
     env_file: docker-compose/.env
+  - path: ./hedgedoc/docker-compose.yaml
+    project_directory: ..
+    env_file: docker-compose/.env

--- a/docker-compose/hedgedoc/docker-compose.yaml
+++ b/docker-compose/hedgedoc/docker-compose.yaml
@@ -1,0 +1,43 @@
+services:
+  hedgedoc:
+    container_name: hedgedoc
+    image: quay.io/hedgedoc/hedgedoc:1.9.9
+    restart: unless-stopped
+    networks:
+      - homelab-network
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      - CMD_PORT=3050
+      - CMD_PROTOCOL_USESSL=true
+      - CMD_ALLOW_EMAIL_REGISTER=${HEDGEDOC_ALLOW_EMAIL_REGISTER}
+      - CMD_IMAGE_UPLOAD_TYPE=filesystem
+      - CMD_DOMAIN=${HEDGEDOC_DOMAIN_URL}
+      - CMD_SESSION_SECRET=${HEDGEDOC_SESSION_SECRET}
+      - CMD_DB_URL=${HEDGEDOC_POSTGRES_URL}
+    volumes:
+      - ~/docker-volumes/hedgedoc/uploads:/hedgedoc/public/uploads
+    ports:
+      - 3050:3050
+    depends_on:
+      - hedgedoc-db
+
+  hedgedoc-db:
+    container_name: hedgedoc-db
+    image: postgres:16.1
+    restart: unless-stopped
+    networks:
+      - homelab-network
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - ~/docker-volumes/hedgedoc/db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=${HEDGEDOC_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${HEDGEDOC_POSTGRES_PASSWORD}
+      - POSTGRES_DB=${HEDGEDOC_POSTGRES_DB}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
Added a new service for Hedgedoc in the docker-compose file. The service includes the necessary configurations and dependencies for running Hedgedoc. The service uses the latest version of the Hedgedoc image (1.9.9) and is set to restart unless stopped. The service is connected to the homelab-network and has the required environment variables for connecting to the Hedgedoc database. The service also includes volume mappings for storing uploads and uses port 3050 for communication. The Hedgedoc service depends on the hedgedoc-database service, which runs a PostgreSQL database. The database is configured with the necessary environment variables and volume mappings. Both services have the necessary security options enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `HedgeDoc` as a new service in our application stack for collaborative markdown note-taking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->